### PR TITLE
Link to the README directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
           <name>Aerogear</name>
         </developer>
     </developers>
-    <url>https://github.com/jenkinsci/kryptowire-plugin/tree/master/docs</url>
+    <url>https://github.com/jenkinsci/kryptowire-plugin/blob/master/docs/README.adoc</url>
     <scm>
         <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>


### PR DESCRIPTION
See https://github.com/jenkins-infra/plugin-site-api/pull/69 -- with the direct link it will be easier to include the README in the plugin page properly.

Related tickets:
https://issues.jenkins-ci.org/browse/WEBSITE-406
https://issues.jenkins-ci.org/browse/JENKINS-59172